### PR TITLE
feat: 이메일 회원가입 및 로그인 추가

### DIFF
--- a/server/src/main/java/godsaeng/server/config/SecurityConfig.java
+++ b/server/src/main/java/godsaeng/server/config/SecurityConfig.java
@@ -1,9 +1,11 @@
 package godsaeng.server.config;
 
+import godsaeng.server.security.EncryptUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -18,5 +20,20 @@ public class SecurityConfig {
                 .formLogin().disable()
                 .headers().frameOptions().disable();
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new PasswordEncoder() {
+            @Override
+            public String encode(CharSequence rawPassword) {
+                return EncryptUtils.encrypt(rawPassword.toString());
+            }
+
+            @Override
+            public boolean matches(CharSequence rawPassword, String encodedPassword) {
+                return encodedPassword.equals(EncryptUtils.encrypt(rawPassword.toString()));
+            }
+        };
     }
 }

--- a/server/src/main/java/godsaeng/server/controller/AuthController.java
+++ b/server/src/main/java/godsaeng/server/controller/AuthController.java
@@ -1,0 +1,31 @@
+package godsaeng.server.controller;
+
+import godsaeng.server.dto.request.AuthLoginRequest;
+import godsaeng.server.dto.response.TokenResponse;
+import godsaeng.server.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Tag(name = "Login", description = "인증")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/login")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "자체 로그인")
+    @PostMapping
+    public ResponseEntity<TokenResponse> login(@RequestBody @Valid AuthLoginRequest request) {
+        TokenResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/src/main/java/godsaeng/server/controller/MemberController.java
+++ b/server/src/main/java/godsaeng/server/controller/MemberController.java
@@ -1,7 +1,9 @@
 package godsaeng.server.controller;
 
+import godsaeng.server.dto.request.MemberSignUpRequest;
 import godsaeng.server.dto.request.OAuthMemberSignUpRequest;
 import godsaeng.server.dto.response.IsDuplicateNicknameResponse;
+import godsaeng.server.dto.response.MemberSignUpResponse;
 import godsaeng.server.dto.response.MyPageResponse;
 import godsaeng.server.dto.response.OAuthMemberSignUpResponse;
 import godsaeng.server.security.auth.LoginUserId;
@@ -22,6 +24,13 @@ import javax.validation.Valid;
 public class MemberController {
 
     private final MemberService memberService;
+
+    @Operation(summary = "이메일 회원가입")
+    @PostMapping
+    public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody @Valid MemberSignUpRequest request) {
+        MemberSignUpResponse response = memberService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
 
     @Operation(summary = "OAuth 회원가입")
     @PostMapping("/oauth")

--- a/server/src/main/java/godsaeng/server/domain/GodSaeng.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaeng.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Table(name = "god_saeng")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GodSaeng {
+public class GodSaeng extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "god_saeng_id")

--- a/server/src/main/java/godsaeng/server/domain/GodSaengMember.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaengMember.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @Table(name = "god_saeng_member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GodSaengMember {
+public class GodSaengMember extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "god_saeng_member_id")

--- a/server/src/main/java/godsaeng/server/domain/Member.java
+++ b/server/src/main/java/godsaeng/server/domain/Member.java
@@ -27,6 +27,9 @@ public class Member extends BaseTime {
     @Column(name = "email", nullable = false)
     private String email;
 
+    @Column(name="password")
+    private String password;
+
     @Column(name = "nickname", unique = true)
     private String nickname;
 
@@ -41,10 +44,11 @@ public class Member extends BaseTime {
     @Column(name = "platform_id")
     private String platformId;
 
-    public Member(String email, String nickname, MemberProfileImage memberProfileImage,
+    public Member(String email, String password, String nickname, MemberProfileImage memberProfileImage,
                   Platform platform, String platformId) {
         validateNickname(nickname);
         this.email = email;
+        this.password = password;
         this.nickname = nickname;
         this.memberProfileImage = memberProfileImage;
         this.platform = platform;
@@ -62,6 +66,10 @@ public class Member extends BaseTime {
         this.memberProfileImage = memberProfileImage;
         this.platform = platform;
         this.platformId = platformId;
+    }
+
+    public Member(String email, String password, String nickname) {
+        this(email, password, nickname, null, Platform.GODSAENG, null);
     }
 
     public void registerOAuthMember(String email, String nickname) {

--- a/server/src/main/java/godsaeng/server/domain/Platform.java
+++ b/server/src/main/java/godsaeng/server/domain/Platform.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 @Getter
 public enum Platform {
 
+    GODSAENG("godsaeng"),
     APPLE("apple"),
     KAKAO("kakao");
 

--- a/server/src/main/java/godsaeng/server/dto/request/AuthLoginRequest.java
+++ b/server/src/main/java/godsaeng/server/dto/request/AuthLoginRequest.java
@@ -1,0 +1,20 @@
+package godsaeng.server.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class AuthLoginRequest {
+
+    @Email(message = "1006:이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String email;
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String password;
+}

--- a/server/src/main/java/godsaeng/server/dto/request/MemberSignUpRequest.java
+++ b/server/src/main/java/godsaeng/server/dto/request/MemberSignUpRequest.java
@@ -1,0 +1,25 @@
+package godsaeng.server.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class MemberSignUpRequest {
+
+    @Email(message = "1004:이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String email;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String password;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String nickname;
+}

--- a/server/src/main/java/godsaeng/server/dto/response/IsDuplicateEmailResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/IsDuplicateEmailResponse.java
@@ -1,0 +1,12 @@
+package godsaeng.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class IsDuplicateEmailResponse {
+
+    private boolean result;
+}

--- a/server/src/main/java/godsaeng/server/dto/response/MemberSignUpResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/MemberSignUpResponse.java
@@ -1,0 +1,14 @@
+package godsaeng.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberSignUpResponse {
+
+    private Long id;
+}

--- a/server/src/main/java/godsaeng/server/dto/response/TokenResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/TokenResponse.java
@@ -1,0 +1,18 @@
+package godsaeng.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TokenResponse {
+    private String token;
+
+    public static TokenResponse from(final String token) {
+        return new TokenResponse(token);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/DuplicateMemberException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/DuplicateMemberException.java
@@ -1,0 +1,11 @@
+package godsaeng.server.exception.badrequest;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateMemberException extends BadRequestException {
+
+    public DuplicateMemberException() {
+        super("이미 존재하는 회원입니다.", 1000);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/DuplicateNicknameException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/DuplicateNicknameException.java
@@ -1,0 +1,11 @@
+package godsaeng.server.exception.badrequest;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateNicknameException extends BadRequestException {
+
+    public DuplicateNicknameException() {
+        super("이미 존재하는 닉네임입니다.", 1004);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/InvalidEmailException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/InvalidEmailException.java
@@ -1,0 +1,8 @@
+package godsaeng.server.exception.badrequest;
+
+public class InvalidEmailException extends BadRequestException {
+
+    public InvalidEmailException() {
+        super("이메일 형식이 올바르지 않습니다.", 1006);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/InvalidPasswordException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/InvalidPasswordException.java
@@ -1,0 +1,8 @@
+package godsaeng.server.exception.badrequest;
+
+public class InvalidPasswordException extends BadRequestException {
+
+    public InvalidPasswordException() {
+        super("비밀번호는 소문자, 숫자를 모두 포함하는 8~20자로 구성되어야 합니다.", 1007);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/PasswordMismatchException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/PasswordMismatchException.java
@@ -1,0 +1,8 @@
+package godsaeng.server.exception.badrequest;
+
+public class PasswordMismatchException extends BadRequestException {
+
+    public PasswordMismatchException() {
+        super("비밀번호가 올바르지 않습니다.", 1003);
+    }
+}

--- a/server/src/main/java/godsaeng/server/repository/MemberRepository.java
+++ b/server/src/main/java/godsaeng/server/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 
     Boolean existsByNickname(String nickname);
+
+    Boolean existsByEmailAndPlatform(String email, Platform platform);
 }

--- a/server/src/main/java/godsaeng/server/repository/MemberRepository.java
+++ b/server/src/main/java/godsaeng/server/repository/MemberRepository.java
@@ -10,6 +10,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 
+    Optional<Member> findByEmailAndPlatform(String email, Platform platform);
+
     Boolean existsByNickname(String nickname);
 
     Boolean existsByEmailAndPlatform(String email, Platform platform);

--- a/server/src/main/java/godsaeng/server/service/AuthService.java
+++ b/server/src/main/java/godsaeng/server/service/AuthService.java
@@ -1,0 +1,42 @@
+package godsaeng.server.service;
+
+import godsaeng.server.domain.Member;
+import godsaeng.server.domain.Platform;
+import godsaeng.server.dto.request.AuthLoginRequest;
+import godsaeng.server.dto.response.TokenResponse;
+import godsaeng.server.exception.badrequest.PasswordMismatchException;
+import godsaeng.server.exception.notfound.NotFoundMemberException;
+import godsaeng.server.repository.MemberRepository;
+import godsaeng.server.security.auth.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    public TokenResponse login(AuthLoginRequest request) {
+        Member findMember = memberRepository.findByEmailAndPlatform(request.getEmail(), Platform.GODSAENG)
+                .orElseThrow(NotFoundMemberException::new);
+        validatePassword(findMember, request.getPassword());
+
+        String token = issueToken(findMember);
+
+        return TokenResponse.from(token);
+    }
+
+    private String issueToken(final Member findMember) {
+        return jwtTokenProvider.createToken(findMember.getId());
+    }
+
+    private void validatePassword(final Member findMember, final String password) {
+        if (!passwordEncoder.matches(password, findMember.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+    }
+}

--- a/server/src/main/java/godsaeng/server/service/MemberService.java
+++ b/server/src/main/java/godsaeng/server/service/MemberService.java
@@ -2,22 +2,73 @@ package godsaeng.server.service;
 
 import godsaeng.server.domain.Member;
 import godsaeng.server.domain.Platform;
+import godsaeng.server.dto.request.MemberSignUpRequest;
 import godsaeng.server.dto.request.OAuthMemberSignUpRequest;
-import godsaeng.server.dto.response.IsDuplicateNicknameResponse;
-import godsaeng.server.dto.response.MyPageResponse;
-import godsaeng.server.dto.response.OAuthMemberSignUpResponse;
-import godsaeng.server.exception.badrequest.InvalidNicknameException;
+import godsaeng.server.dto.response.*;
+import godsaeng.server.exception.badrequest.*;
 import godsaeng.server.exception.notfound.NotFoundMemberException;
 import godsaeng.server.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final Pattern PASSWORD_REGEX = Pattern.compile("^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,20}$");
+
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public MemberSignUpResponse signUp(MemberSignUpRequest request) {
+        validatePassword(request.getPassword());
+        validateDuplicateMember(request);
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        try {
+            Member member = new Member(request.getEmail(), encodedPassword, request.getNickname());
+            return new MemberSignUpResponse(memberRepository.save(member).getId());
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateMemberException();
+        }
+    }
+
+    private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {
+        if (memberRepository.existsByEmailAndPlatform(memberSignUpRequest.getEmail(), Platform.GODSAENG)) {
+            throw new DuplicateMemberException();
+        }
+        validateDuplicateNickname(memberSignUpRequest.getNickname());
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        if (memberRepository.existsByNickname(nickname))
+            throw new DuplicateNicknameException();
+    }
+
+    private void validatePassword(String password) {
+        if (!PASSWORD_REGEX.matcher(password).matches()) {
+            throw new InvalidPasswordException();
+        }
+    }
+
+    public IsDuplicateEmailResponse isDuplicateEmail(String email) {
+        validateEmail(email);
+
+        boolean existsEmail = memberRepository.existsByEmailAndPlatform(email, Platform.GODSAENG);
+        return new IsDuplicateEmailResponse(existsEmail);
+    }
+
+    private void validateEmail(String email) {
+        if (email.isBlank()) {
+            throw new InvalidEmailException();
+        }
+    }
 
     @Transactional
     public OAuthMemberSignUpResponse signUpByOAuthMember(OAuthMemberSignUpRequest request) {

--- a/server/src/test/java/godsaeng/server/security/EncryptUtilsTest.java
+++ b/server/src/test/java/godsaeng/server/security/EncryptUtilsTest.java
@@ -1,0 +1,19 @@
+package godsaeng.server.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EncryptUtilsTest {
+
+    @Test
+    @DisplayName("입력이 주어지면 해당 문자열을 암호화한다")
+    void encrypt() {
+        String given = "abc123";
+
+        String actual = EncryptUtils.encrypt(given);
+
+        assertThat(actual).isNotEqualTo(given);
+    }
+}

--- a/server/src/test/java/godsaeng/server/security/auth/AuthorizationExtractorTest.java
+++ b/server/src/test/java/godsaeng/server/security/auth/AuthorizationExtractorTest.java
@@ -1,0 +1,22 @@
+package godsaeng.server.security.auth;
+
+import godsaeng.server.exception.badrequest.BlankTokenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthorizationExtractorTest {
+
+    @DisplayName("공백 값으로 access token 추출을 시도하면 예외를 반환한다")
+    @Test
+    void extractAccessTokenByBlankToken() {
+        String token = "Bearer ";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", token);
+
+        assertThatThrownBy(() -> AuthorizationExtractor.extractAccessToken(request))
+                .isInstanceOf(BlankTokenException.class);
+    }
+}

--- a/server/src/test/java/godsaeng/server/security/auth/JwtTokenProviderTest.java
+++ b/server/src/test/java/godsaeng/server/security/auth/JwtTokenProviderTest.java
@@ -1,0 +1,83 @@
+package godsaeng.server.security.auth;
+
+import godsaeng.server.exception.unauthorized.InvalidTokenException;
+import godsaeng.server.exception.unauthorized.TokenExpiredException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class JwtTokenProviderTest {
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    private String token;
+
+    @DisplayName("payload 정보를 통해 유효한 JWT 토큰을 생성한다")
+    @Test
+    public void createToken() {
+        Long payload = 1L;
+
+        String token = jwtTokenProvider.createToken(payload);
+
+        Assertions.assertNotNull(token);
+        Assertions.assertTrue(token.length() > 0);
+    }
+
+    @DisplayName("올바른 토큰 정보로 payload를 조회한다")
+    @Test
+    void getPayload() {
+        token = jwtTokenProvider.createToken(1L);
+
+        String payload = jwtTokenProvider.getPayload(token);
+
+        assertThat(jwtTokenProvider.getPayload(token)).isEqualTo(payload);
+    }
+
+    @DisplayName("유효하지 않은 토큰 형식의 토큰으로 payload를 조회할 경우 예외를 발생시킨다")
+    @Test
+    void getPayloadByInvalidToken() {
+        String invalidToken = "invalid-token";
+
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(invalidToken))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @DisplayName("만료된 토큰으로 payload를 조회할 경우 예외를 발생시킨다")
+    @Test
+    void getPayloadByExpiredToken() {
+        long expirationMillis = 1L;
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider("secret-key", expirationMillis);
+        Long expiredPayload = 1L;
+
+        String expiredToken = jwtTokenProvider.createToken(expiredPayload);
+        try {
+            Thread.sleep(expirationMillis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThatThrownBy(() -> jwtTokenProvider.getPayload(expiredToken))
+                .isInstanceOf(TokenExpiredException.class);
+    }
+
+    @DisplayName("시크릿 키가 틀린 토큰 정보로 payload를 조회할 경우 예외를 발생시킨다")
+    @Test
+    void getPayloadByWrongSecretKeyToken() {
+        Long payload = 1L;
+        String correctSecretKey = "correct-secret-key";
+        String wrongSecretKey = "wrong-secret-key";
+
+        JwtTokenProvider tokenProvider = new JwtTokenProvider(correctSecretKey, 3600000L);
+        String token = tokenProvider.createToken(payload);
+
+        assertThatExceptionOfType(InvalidTokenException.class)
+                .isThrownBy(() -> {
+                    JwtTokenProvider wrongTokenProvider = new JwtTokenProvider(wrongSecretKey, 3600000L);
+                    wrongTokenProvider.getPayload(token);
+                });
+    }
+}

--- a/server/src/test/java/godsaeng/server/service/AuthServiceTest.java
+++ b/server/src/test/java/godsaeng/server/service/AuthServiceTest.java
@@ -1,0 +1,62 @@
+package godsaeng.server.service;
+
+import godsaeng.server.domain.Member;
+import godsaeng.server.dto.request.AuthLoginRequest;
+import godsaeng.server.dto.response.TokenResponse;
+import godsaeng.server.exception.badrequest.PasswordMismatchException;
+import godsaeng.server.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class AuthServiceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원 로그인 요청이 옳다면 토큰을 발급한다")
+    void login() {
+        String email = "dlawotn3@naver.com";
+        String password = "a1b2c3d4";
+        String encodedPassword = passwordEncoder.encode("a1b2c3d4");
+        Member member = new Member("dlawotn3@naver.com", encodedPassword, "메리");
+        memberRepository.save(member);
+        AuthLoginRequest loginRequest = new AuthLoginRequest(email, password);
+
+        TokenResponse tokenResponse = authService.login(loginRequest);
+
+        assertNotNull(tokenResponse.getToken());
+    }
+
+    @Test
+    @DisplayName("회원 로그인 요청이 올바르지 않다면 예외가 발생한다")
+    void loginWithException() {
+        String email = "dlawotn3@naver.com";
+        String password = "a1b2c3d4";
+        String encodedPassword = passwordEncoder.encode(password);
+        Member member = new Member(email, encodedPassword, "메리");
+        memberRepository.save(member);
+
+        AuthLoginRequest loginRequest = new AuthLoginRequest(email, "wrongPassword");
+
+        assertThrows(PasswordMismatchException.class,
+                () -> authService.login(loginRequest));
+    }
+}


### PR DESCRIPTION
로컬에서 테스트를 위해 이메일 회원가입 및 로그인 추가했습니다.
회원가입 조건은 모카콩과 동일합니다.