### PR TITLE
feat: 인증 등록 POST API 구현

### DIFF
--- a/server/src/main/java/godsaeng/server/controller/GodSaengController.java
+++ b/server/src/main/java/godsaeng/server/controller/GodSaengController.java
@@ -9,8 +9,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Godsaengs", description = "같생")
 @RestController
@@ -39,16 +41,19 @@ public class GodSaengController {
     @Operation(summary = "같생 참가 신청")
     @SecurityRequirement(name = "JWT")
     @PostMapping("/attend/{godSaengId}")
-    public ResponseEntity<Void> attendGodSaeng(@LoginUserId Long memberId,@PathVariable Long godSaengId) {
+    public ResponseEntity<Void> attendGodSaeng(@LoginUserId Long memberId, @PathVariable Long godSaengId) {
         godSaengService.attendGodSaeng(memberId, godSaengId);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "같생 인증 등록")
     @SecurityRequirement(name = "JWT")
-    @PostMapping("/proof/{godSaengId}")
-    public ResponseEntity<Void> saveProof(@LoginUserId Long memberId,@PathVariable Long godSaengId) {
-        godSaengService.saveProof(memberId, godSaengId);
+    @PostMapping("/proof/{godSaengId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> saveProof(
+            @LoginUserId Long memberId,
+            @PathVariable Long godSaengId,
+            @RequestParam(value = "file", required = false) MultipartFile multipartFile) {
+        godSaengService.saveProof(memberId, godSaengId, multipartFile);
         return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/godsaeng/server/controller/GodSaengController.java
+++ b/server/src/main/java/godsaeng/server/controller/GodSaengController.java
@@ -21,7 +21,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/godsaeng")
-@Slf4j
 public class GodSaengController {
 
     private final GodSaengService godSaengService;

--- a/server/src/main/java/godsaeng/server/controller/GodSaengController.java
+++ b/server/src/main/java/godsaeng/server/controller/GodSaengController.java
@@ -43,4 +43,12 @@ public class GodSaengController {
         godSaengService.attendGodSaeng(memberId, godSaengId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "같생 인증 등록")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping("/proof/{godSaengId}")
+    public ResponseEntity<Void> saveProof(@LoginUserId Long memberId,@PathVariable Long godSaengId) {
+        godSaengService.saveProof(memberId, godSaengId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/server/src/main/java/godsaeng/server/controller/GodSaengController.java
+++ b/server/src/main/java/godsaeng/server/controller/GodSaengController.java
@@ -1,14 +1,17 @@
 package godsaeng.server.controller;
 
 import godsaeng.server.dto.request.GodSaengSaveRequest;
+import godsaeng.server.dto.request.ProofSaveRequest;
 import godsaeng.server.dto.response.GodSaengSaveResponse;
 import godsaeng.server.dto.response.GodSaengsResponse;
+import godsaeng.server.dto.response.ProofSaveResponse;
 import godsaeng.server.security.auth.LoginUserId;
 import godsaeng.server.service.GodSaengService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/godsaeng")
+@Slf4j
 public class GodSaengController {
 
     private final GodSaengService godSaengService;
@@ -25,7 +29,8 @@ public class GodSaengController {
     @Operation(summary = "같생 등록")
     @SecurityRequirement(name = "JWT")
     @PostMapping
-    public ResponseEntity<GodSaengSaveResponse> save(@LoginUserId Long memberId, @RequestBody GodSaengSaveRequest request) {
+    public ResponseEntity<GodSaengSaveResponse> save(@LoginUserId Long memberId
+            , @RequestBody GodSaengSaveRequest request) {
         GodSaengSaveResponse response = godSaengService.save(memberId, request);
         return ResponseEntity.ok(response);
     }
@@ -48,12 +53,13 @@ public class GodSaengController {
 
     @Operation(summary = "같생 인증 등록")
     @SecurityRequirement(name = "JWT")
-    @PostMapping("/proof/{godSaengId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> saveProof(
-            @LoginUserId Long memberId,
-            @PathVariable Long godSaengId,
-            @RequestParam(value = "file", required = false) MultipartFile multipartFile) {
-        godSaengService.saveProof(memberId, godSaengId, multipartFile);
-        return ResponseEntity.ok().build();
+    @PostMapping(value = "/proof/{godSaengId}", consumes = {MediaType.APPLICATION_JSON_VALUE,
+            MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ProofSaveResponse> saveProof(@LoginUserId Long memberId,
+                                                       @PathVariable Long godSaengId,
+                                                       @RequestPart ProofSaveRequest request,
+                                                       @RequestPart MultipartFile multipartFile) {
+        ProofSaveResponse response = godSaengService.saveProof(memberId, godSaengId, multipartFile, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/server/src/main/java/godsaeng/server/domain/GodSaeng.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaeng.java
@@ -1,7 +1,6 @@
 package godsaeng.server.domain;
 
 
-import godsaeng.server.exception.badrequest.DuplicateWeekException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +14,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GodSaeng extends BaseTime {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "god_saeng_id")
@@ -22,6 +22,7 @@ public class GodSaeng extends BaseTime {
 
     @Column(name = "title", nullable = false)
     private String title;
+
     @Column(name = "description")
     private String description;
 

--- a/server/src/main/java/godsaeng/server/domain/GodSaeng.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaeng.java
@@ -37,7 +37,6 @@ public class GodSaeng extends BaseTime {
     @JoinColumn(name = "member_id")
     private Member owner;
 
-
     @OneToMany(mappedBy = "godSaeng", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<GodSaengMember> members = new ArrayList<>();
 

--- a/server/src/main/java/godsaeng/server/domain/Proof.java
+++ b/server/src/main/java/godsaeng/server/domain/Proof.java
@@ -28,9 +28,14 @@ public class Proof extends BaseTime {
     @JoinColumn(name = "proof_image_id")
     private ProofImage proofImage;
 
-    public Proof(String content, GodSaeng godSaeng, ProofImage proofImage) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public Proof(String content, GodSaeng godSaeng, ProofImage proofImage, Member member) {
         this.content = content;
         this.godSaeng = godSaeng;
         this.proofImage = proofImage;
+        this.member = member;
     }
 }

--- a/server/src/main/java/godsaeng/server/domain/Proof.java
+++ b/server/src/main/java/godsaeng/server/domain/Proof.java
@@ -17,8 +17,8 @@ public class Proof extends BaseTime {
     @Column(name = "proof_id")
     private Long id;
 
-    @Column(name = "description")
-    private String description;
+    @Column(name = "content")
+    private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "god_saeng_id")
@@ -28,8 +28,8 @@ public class Proof extends BaseTime {
     @JoinColumn(name = "proof_image_id")
     private ProofImage proofImage;
 
-    public Proof(String description, GodSaeng godSaeng, ProofImage proofImage) {
-        this.description = description;
+    public Proof(String content, GodSaeng godSaeng, ProofImage proofImage) {
+        this.content = content;
         this.godSaeng = godSaeng;
         this.proofImage = proofImage;
     }

--- a/server/src/main/java/godsaeng/server/domain/Proof.java
+++ b/server/src/main/java/godsaeng/server/domain/Proof.java
@@ -1,0 +1,36 @@
+package godsaeng.server.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "proof")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Proof extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "proof_id")
+    private Long id;
+
+    @Column(name = "description")
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "god_saeng_id")
+    private GodSaeng godSaeng;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "proof_image_id")
+    private ProofImage proofImage;
+
+    public Proof(String description, GodSaeng godSaeng, ProofImage proofImage) {
+        this.description = description;
+        this.godSaeng = godSaeng;
+        this.proofImage = proofImage;
+    }
+}

--- a/server/src/main/java/godsaeng/server/domain/ProofImage.java
+++ b/server/src/main/java/godsaeng/server/domain/ProofImage.java
@@ -21,6 +21,15 @@ public class ProofImage extends BaseTime {
     @Column(name = "img_url", nullable = false)
     private String imgUrl;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "god_saeng_id")
+    private GodSaeng godSaeng;
+
+    public ProofImage(String imgUrl, GodSaeng godSaeng) {
+        this.imgUrl = imgUrl;
+        this.godSaeng = godSaeng;
+    }
+
     public ProofImage(String imgUrl) {
         this.imgUrl = imgUrl;
     }

--- a/server/src/main/java/godsaeng/server/domain/ProofImage.java
+++ b/server/src/main/java/godsaeng/server/domain/ProofImage.java
@@ -1,0 +1,27 @@
+package godsaeng.server.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "proof_image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProofImage extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "proof_image_id")
+    private Long id;
+
+    @Lob
+    @Column(name = "img_url", nullable = false)
+    private String imgUrl;
+
+    public ProofImage(String imgUrl) {
+        this.imgUrl = imgUrl;
+    }
+}

--- a/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
+++ b/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
@@ -1,0 +1,15 @@
+package godsaeng.server.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class ProofSaveRequest {
+
+    @NotBlank(message = "2001:공백일 수 없습니다.")
+    private String proofContent;
+}

--- a/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
+++ b/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
@@ -5,8 +5,6 @@ import lombok.*;
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @ToString
 public class ProofSaveRequest {
 

--- a/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
+++ b/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
@@ -4,6 +4,8 @@ import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @ToString
 public class ProofSaveRequest {

--- a/server/src/main/java/godsaeng/server/dto/response/ProofSaveResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/ProofSaveResponse.java
@@ -1,0 +1,12 @@
+package godsaeng.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class ProofSaveResponse {
+
+    private Long id;
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/DuplicateProofException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/DuplicateProofException.java
@@ -1,0 +1,8 @@
+package godsaeng.server.exception.badrequest;
+
+public class DuplicateProofException extends BadRequestException {
+
+    public DuplicateProofException() {
+        super("이미 등록한 인증입니다.", 3001);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/InvalidProofMemberException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/InvalidProofMemberException.java
@@ -3,6 +3,6 @@ package godsaeng.server.exception.badrequest;
 public class InvalidProofMemberException extends BadRequestException {
 
     public InvalidProofMemberException() {
-        super("해당 같생에 참여한 회원이 아닙니다.", 1006);
+        super("해당 같생에 참여한 회원이 아닙니다.", 3002);
     }
 }

--- a/server/src/main/java/godsaeng/server/exception/badrequest/InvalidProofMemberException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/InvalidProofMemberException.java
@@ -1,0 +1,8 @@
+package godsaeng.server.exception.badrequest;
+
+public class InvalidProofMemberException extends BadRequestException {
+
+    public InvalidProofMemberException() {
+        super("해당 같생에 참여한 회원이 아닙니다.", 1006);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/InvalidProofStatusException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/InvalidProofStatusException.java
@@ -1,0 +1,8 @@
+package godsaeng.server.exception.badrequest;
+
+public class InvalidProofStatusException extends BadRequestException {
+
+    public InvalidProofStatusException() {
+        super("인증 기간이 올바르지 않습니다.", 3003);
+    }
+}

--- a/server/src/main/java/godsaeng/server/exception/badrequest/NotExistsProofImageException.java
+++ b/server/src/main/java/godsaeng/server/exception/badrequest/NotExistsProofImageException.java
@@ -1,0 +1,8 @@
+package godsaeng.server.exception.badrequest;
+
+public class NotExistsProofImageException extends BadRequestException {
+
+    public NotExistsProofImageException() {
+        super("등록하려는 인증 사진이 없습니다.", 3000);
+    }
+}

--- a/server/src/main/java/godsaeng/server/repository/GodSaengMemberRepository.java
+++ b/server/src/main/java/godsaeng/server/repository/GodSaengMemberRepository.java
@@ -1,7 +1,10 @@
 package godsaeng.server.repository;
 
+import godsaeng.server.domain.GodSaeng;
 import godsaeng.server.domain.GodSaengMember;
+import godsaeng.server.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GodSaengMemberRepository extends JpaRepository<GodSaengMember, Long> {
+    boolean existsByGodSaengAndMember(GodSaeng godSaeng, Member member);
 }

--- a/server/src/main/java/godsaeng/server/repository/ProofImageRepository.java
+++ b/server/src/main/java/godsaeng/server/repository/ProofImageRepository.java
@@ -1,0 +1,8 @@
+package godsaeng.server.repository;
+
+import godsaeng.server.domain.ProofImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProofImageRepository extends JpaRepository<ProofImage, Long> {
+
+}

--- a/server/src/main/java/godsaeng/server/repository/ProofRepopsitory.java
+++ b/server/src/main/java/godsaeng/server/repository/ProofRepopsitory.java
@@ -1,7 +1,12 @@
 package godsaeng.server.repository;
 
+import godsaeng.server.domain.GodSaeng;
+import godsaeng.server.domain.Member;
 import godsaeng.server.domain.Proof;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProofRepopsitory extends JpaRepository<Proof, Long> {
+    Optional<Proof> findTopByMemberAndGodSaengOrderByCreatedTimeDesc(Member member, GodSaeng godSaeng);
 }

--- a/server/src/main/java/godsaeng/server/repository/ProofRepopsitory.java
+++ b/server/src/main/java/godsaeng/server/repository/ProofRepopsitory.java
@@ -1,0 +1,7 @@
+package godsaeng.server.repository;
+
+import godsaeng.server.domain.Proof;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProofRepopsitory extends JpaRepository<Proof, Long> {
+}

--- a/server/src/main/java/godsaeng/server/service/GodSaengService.java
+++ b/server/src/main/java/godsaeng/server/service/GodSaengService.java
@@ -110,9 +110,10 @@ public class GodSaengService {
 
     @Transactional
     public void validateProofCondition(Member member, GodSaeng godSaeng) {
-        if (godSaeng.getStatus() != GodSaengStatus.DOING) {
-            throw new InvalidProofStatusException();
-        }
+        // TODO: 같생 진행 여부에 따른 검증 코드 추가 필요
+//        if (godSaeng.getStatus() != GodSaengStatus.DOING) {
+//            throw new InvalidProofStatusException();
+//        }
         if (!godSaengMemberRepository.existsByGodSaengAndMember(godSaeng, member)) {
             throw new InvalidProofMemberException();
         }
@@ -128,7 +129,6 @@ public class GodSaengService {
 
         if (mostRecentProof.isPresent()) {
             LocalDateTime recentProofCreatedTime = mostRecentProof.get().getCreatedTime().toLocalDateTime();
-
             // 현재 시간과 가장 최근 갓생 인증글 생성 시간 비교
             if (now.toLocalDate().isEqual(recentProofCreatedTime.toLocalDate())) {
                 throw new DuplicateProofException();

--- a/server/src/main/java/godsaeng/server/service/GodSaengService.java
+++ b/server/src/main/java/godsaeng/server/service/GodSaengService.java
@@ -1,24 +1,25 @@
 package godsaeng.server.service;
 
-import godsaeng.server.domain.GodSaeng;
-import godsaeng.server.domain.GodSaengMember;
-import godsaeng.server.domain.GodSaengWeek;
-import godsaeng.server.domain.Member;
+import godsaeng.server.domain.*;
 import godsaeng.server.dto.request.GodSaengSaveRequest;
 import godsaeng.server.dto.response.GodSaengResponse;
 import godsaeng.server.dto.response.GodSaengSaveResponse;
 import godsaeng.server.dto.response.GodSaengsResponse;
 import godsaeng.server.exception.badrequest.DuplicateGodSaengException;
 import godsaeng.server.exception.badrequest.DuplicateWeekException;
+import godsaeng.server.exception.badrequest.NotExistsProofImageException;
 import godsaeng.server.exception.notfound.NotFoundGodSaengException;
 import godsaeng.server.exception.notfound.NotFoundMemberException;
 import godsaeng.server.repository.GodSaengMemberRepository;
 import godsaeng.server.repository.GodSaengRepository;
 import godsaeng.server.repository.MemberRepository;
+import godsaeng.server.repository.ProofRepopsitory;
+import godsaeng.server.support.AwsS3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,6 +31,8 @@ public class GodSaengService {
     private final GodSaengRepository godSaengRepository;
     private final MemberRepository memberRepository;
     private final GodSaengMemberRepository godSaengMemberRepository;
+    private final ProofRepopsitory proofRepopsitory;
+    private final AwsS3Uploader awsS3Uploader;
 
     @Transactional
     public GodSaengSaveResponse save(Long memberId, GodSaengSaveRequest request) {
@@ -73,4 +76,35 @@ public class GodSaengService {
         }
     }
 
+    @Transactional
+    public void saveProof(Long memberId, Long godSaengId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        GodSaeng godSaeng = godSaengRepository.findById(godSaengId)
+                .orElseThrow(NotFoundGodSaengException::new);
+
+        try {
+
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateGodSaengException();
+        }
+    }
+
+    @Transactional
+    public void saveProofImage(Long memberId, Long godSaengId, MultipartFile proofImg) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        GodSaeng godSaeng = godSaengRepository.findById(godSaengId)
+                .orElseThrow(NotFoundGodSaengException::new);
+
+        if (proofImg == null) {
+            throw new NotExistsProofImageException();
+        }
+
+        String proofImgUrl = awsS3Uploader.uploadImage(proofImg);
+        ProofImage proofImage = new ProofImage(proofImgUrl, godSaeng);
+        Proof proof = new Proof()
+        godSaengRepository.save(memberProfileImage);
+        member.updateProfileImgUrl(memberProfileImage);
+    }
 }

--- a/server/src/main/java/godsaeng/server/service/GodSaengService.java
+++ b/server/src/main/java/godsaeng/server/service/GodSaengService.java
@@ -94,8 +94,7 @@ public class GodSaengService {
         }
     }
 
-    @Transactional
-    public ProofImage saveProofImage(Long godSaengId, MultipartFile proofImg) {
+    private ProofImage saveProofImage(Long godSaengId, MultipartFile proofImg) {
         GodSaeng godSaeng = godSaengRepository.findById(godSaengId)
                 .orElseThrow(NotFoundGodSaengException::new);
         if (proofImg == null) {
@@ -108,8 +107,7 @@ public class GodSaengService {
         return proofImage;
     }
 
-    @Transactional
-    public void validateProofCondition(Member member, GodSaeng godSaeng) {
+    private void validateProofCondition(Member member, GodSaeng godSaeng) {
         // TODO: 같생 진행 여부에 따른 검증 코드 추가 필요
 //        if (godSaeng.getStatus() != GodSaengStatus.DOING) {
 //            throw new InvalidProofStatusException();
@@ -120,8 +118,7 @@ public class GodSaengService {
         validateProofDay(member, godSaeng);
     }
 
-    @Transactional
-    public void validateProofDay(Member member, GodSaeng godSaeng) {
+    private void validateProofDay(Member member, GodSaeng godSaeng) {
         LocalDateTime now = LocalDateTime.now();
         // 같은 같생 인증 글 중 사용자가 등록한 가장 최신의 인증글
         Optional<Proof> mostRecentProof = proofRepository

--- a/server/src/main/java/godsaeng/server/service/GodSaengService.java
+++ b/server/src/main/java/godsaeng/server/service/GodSaengService.java
@@ -82,13 +82,10 @@ public class GodSaengService {
                 .orElseThrow(NotFoundMemberException::new);
         GodSaeng godSaeng = godSaengRepository.findById(godSaengId)
                 .orElseThrow(NotFoundGodSaengException::new);
-        if (!godSaengMemberRepository.existsByGodSaengAndMember(godSaeng, member)) {
-            throw new InvalidProofMemberException();
-        }
-        String content = request.getProofContent();
-        validateProofDay(member, godSaeng);
+        validateProofCondition(member, godSaeng);
 
         try {
+            String content = request.getProofContent();
             ProofImage proofImage = saveProofImage(godSaengId, proofImg);
             Proof proof = new Proof(content, godSaeng, proofImage, member);
             return new ProofSaveResponse(proofRepository.save(proof).getId());
@@ -109,6 +106,17 @@ public class GodSaengService {
         ProofImage proofImage = new ProofImage(proofImgUrl, godSaeng);
         proofImageRepository.save(proofImage);
         return proofImage;
+    }
+
+    @Transactional
+    public void validateProofCondition(Member member, GodSaeng godSaeng) {
+        if (godSaeng.getStatus() != GodSaengStatus.DOING) {
+            throw new InvalidProofStatusException();
+        }
+        if (!godSaengMemberRepository.existsByGodSaengAndMember(godSaeng, member)) {
+            throw new InvalidProofMemberException();
+        }
+        validateProofDay(member, godSaeng);
     }
 
     @Transactional

--- a/server/src/test/java/godsaeng/server/service/GodSaengServiceTest.java
+++ b/server/src/test/java/godsaeng/server/service/GodSaengServiceTest.java
@@ -2,26 +2,36 @@ package godsaeng.server.service;
 
 import godsaeng.server.domain.*;
 import godsaeng.server.dto.request.GodSaengSaveRequest;
+import godsaeng.server.dto.request.ProofSaveRequest;
 import godsaeng.server.dto.response.GodSaengSaveResponse;
 import godsaeng.server.dto.response.GodSaengsResponse;
 import godsaeng.server.exception.badrequest.DuplicateGodSaengException;
+import godsaeng.server.exception.badrequest.DuplicateProofException;
+import godsaeng.server.exception.badrequest.InvalidProofMemberException;
+import godsaeng.server.exception.notfound.NotFoundGodSaengException;
 import godsaeng.server.repository.GodSaengRepository;
 import godsaeng.server.repository.MemberRepository;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import godsaeng.server.repository.ProofRepopsitory;
+import godsaeng.server.support.AwsS3Uploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Transactional
@@ -33,14 +43,18 @@ class GodSaengServiceTest {
     private GodSaengService godSaengService;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private ProofRepopsitory proofRepository;
+
+    @MockBean
+    private AwsS3Uploader awsS3Uploader;
 
     @PersistenceContext
     private EntityManager em;
 
-
-    @DisplayName("같생을 저장할 수 있다.")
+    @DisplayName("같생을 저장할 수 있다")
     @Test
-    void save() {
+    void saveGodSaeng() {
         String title = "아침 6시 반 기상 갓생 살기";
         String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
         List<Week> weeks = new ArrayList<>();
@@ -63,9 +77,9 @@ class GodSaengServiceTest {
         assertEquals(1, actual.size());
     }
 
-    @DisplayName("같생을 조회할 수 있다.")
+    @DisplayName("같생을 조회할 수 있다")
     @Test
-    void findAll() {
+    void findAllGodSaeng() {
         String title = "아침 6시 반 기상 갓생 살기";
         String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
         List<GodSaengWeek> weeks = new ArrayList<>();
@@ -86,7 +100,7 @@ class GodSaengServiceTest {
         assertEquals(2, allGodSaeng.getGodsaengs().size());
     }
 
-    @DisplayName("같생에 참가 신청할 수 있다.")
+    @DisplayName("같생에 참가 신청할 수 있다")
     @Test
     void attendGodSaeng() {
         String title = "아침 6시 반 기상 갓생 살기";
@@ -112,7 +126,7 @@ class GodSaengServiceTest {
         assertEquals(2, actual.getMembers().size());
     }
 
-    @DisplayName("같은 같생에 중복 참가 신청할 수 없다.")
+    @DisplayName("같은 같생에 중복 참가 신청할 수 없다")
     @Test
     void validateDuplicateAttendGodSaeng() {
         String title = "아침 6시 반 기상 갓생 살기";
@@ -134,5 +148,101 @@ class GodSaengServiceTest {
         em.flush();
 
         assertThrows(DuplicateGodSaengException.class, () -> godSaengService.attendGodSaeng(savedMember2.getId(), savedGodSaeng.getId()));
+    }
+
+    @DisplayName("같생에 인증 글을 올릴 수 있다")
+    @Test
+    void saveProof() throws IOException {
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
+        weeks.add(Week.TUE);
+        String email = "dlawotn3@naver.com";
+        Member savedMember = memberRepository.save(new Member(email, Platform.KAKAO, "11111"));
+        GodSaengSaveResponse savedGodSaeng = godSaengService.save(savedMember.getId(),
+                new GodSaengSaveRequest("아침 6시 반 기상 갓생 살기",
+                "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.", weeks));
+        String expected = "test_img.jpg";
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg",
+                fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        ProofSaveRequest request = new ProofSaveRequest("hihih");
+        godSaengService.saveProof(savedMember.getId(), savedGodSaeng.getId(), mockMultipartFile, request);
+
+        List<Proof> actual = proofRepository.findAll();
+        em.clear();
+        em.flush();
+
+        assertThat(actual.size()).isEqualTo(1);
+        assertThat(actual.get(0).getContent()).isEqualTo("hihih");
+        assertThat(actual.get(0).getMember()).isEqualTo(savedMember);
+        assertThat(actual.get(0).getProofImage()).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 같생에 대해 인증 글을 올릴 수 없다")
+    @Test
+    void saveProofNotExistsGodSaeng() throws IOException{
+        String email = "dlawotn3@naver.com";
+        Member savedMember = memberRepository.save(new Member(email, Platform.KAKAO, "11111"));
+        String expected = "test_img.jpg";
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg",
+                fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        ProofSaveRequest request = new ProofSaveRequest("hihih");
+
+        assertThrows(NotFoundGodSaengException.class,
+                () -> godSaengService.saveProof(savedMember.getId(), 9999L, mockMultipartFile,
+                        request));
+    }
+
+    @DisplayName("참가 신청을 안 한 같생에는 인증 글을 올릴 수 없다")
+    @Test
+    void saveProofNotAttend() throws IOException {
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
+        weeks.add(Week.TUE);
+        String email = "dlawotn3@naver.com";
+        Member savedMember1 = memberRepository.save(new Member(email, Platform.KAKAO, "11111"));
+        Member savedMember2 = memberRepository.save(new Member("dlawotn1@naver.com", Platform.KAKAO,
+                "11111"));
+        GodSaengSaveResponse savedGodSaeng = godSaengService.save(savedMember1.getId(),
+                new GodSaengSaveRequest("아침 6시 반 기상 갓생 살기",
+                        "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.", weeks));
+        String expected = "test_img.jpg";
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg",
+                fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        ProofSaveRequest request = new ProofSaveRequest("hihih");
+
+        assertThrows(InvalidProofMemberException.class,
+                () -> godSaengService.saveProof(savedMember2.getId(), savedGodSaeng.getId(), mockMultipartFile,
+                        request));
+    }
+
+    @DisplayName("회원은 같은 같생에 대해 하루에 두 번 이상 인증 글을 올릴 수 없다")
+    @Test
+    void saveProof2Times() throws IOException {
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
+        weeks.add(Week.TUE);
+        String email = "dlawotn3@naver.com";
+        Member savedMember = memberRepository.save(new Member(email, Platform.KAKAO, "11111"));
+        GodSaengSaveResponse savedGodSaeng = godSaengService.save(savedMember.getId(),
+                new GodSaengSaveRequest("아침 6시 반 기상 갓생 살기",
+                        "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.", weeks));
+        String expected = "test_img.jpg";
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg",
+                fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        ProofSaveRequest request = new ProofSaveRequest("hihih");
+        godSaengService.saveProof(savedMember.getId(), savedGodSaeng.getId(), mockMultipartFile,
+                request);
+
+        assertThrows(DuplicateProofException.class,
+                () -> godSaengService.saveProof(savedMember.getId(), savedGodSaeng.getId(), mockMultipartFile,
+                        request));
     }
 }


### PR DESCRIPTION
### 개요
참가 신청한 같생 챌린지에 대해 인증을 등록하는 API를 구현했습니다.

### 구현사항
+ Proof 및 ProofImage 엔티티 생성
+ 인증 등록 POST API 구현
  + 참가한 같생에 대해서만 인증 가능하도록 검증
  + 같은 날에 두 번 이상 인증 등록하지 못하도록 예외 처리
  + 같생 진행 여부에 따른 검증 코드 추가 필요 -> GodSaengStatus 처리가 된 코드가 생기면 투두 주석처리 한 곳에 추가 예정
+ 인증 등록 POST API 테스트 코드 추가

### 주의사항
+ 로컬에서 테스트 시, **Postman**(스웨거 불가)으로 아래와 같은 형식으로 적절한 mediaType을 맞춰 요청해야 합니다.
  + request Body의 proofContent 내용은 꼭 json 형태로 보내주어야 합니다
<img width="874" alt="image" src="https://github.com/mocacong-hackathonKU/godsaeng/assets/69844138/50a24272-a290-470c-9545-0930da558921">