### PR TITLE
feat: 월간 조회 기능 구현

### DIFF
--- a/server/src/main/java/godsaeng/server/controller/GodSaengController.java
+++ b/server/src/main/java/godsaeng/server/controller/GodSaengController.java
@@ -4,6 +4,7 @@ import godsaeng.server.dto.request.GodSaengSaveRequest;
 import godsaeng.server.dto.request.ProofSaveRequest;
 import godsaeng.server.dto.response.GodSaengSaveResponse;
 import godsaeng.server.dto.response.GodSaengsResponse;
+import godsaeng.server.dto.response.MonthlyGodSaengsResponse;
 import godsaeng.server.dto.response.ProofSaveResponse;
 import godsaeng.server.security.auth.LoginUserId;
 import godsaeng.server.service.GodSaengService;
@@ -11,10 +12,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
 
 @Tag(name = "Godsaengs", description = "같생")
 @RestController
@@ -47,6 +51,15 @@ public class GodSaengController {
     public ResponseEntity<Void> attendGodSaeng(@LoginUserId Long memberId, @PathVariable Long godSaengId) {
         godSaengService.attendGodSaeng(memberId, godSaengId);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "같생 월간 조회")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping("/monthly")
+    public ResponseEntity<MonthlyGodSaengsResponse> findMonthlyGodSaeng(@LoginUserId Long memberId,
+                                                    @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        MonthlyGodSaengsResponse monthlyGodSaeng = godSaengService.findMonthlyGodSaeng(memberId, date);
+        return ResponseEntity.ok(monthlyGodSaeng);
     }
 
     @Operation(summary = "같생 인증 등록")

--- a/server/src/main/java/godsaeng/server/domain/GodSaeng.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaeng.java
@@ -1,20 +1,27 @@
 package godsaeng.server.domain;
 
 
-import godsaeng.server.exception.badrequest.DuplicateWeekException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Entity
 @Table(name = "god_saeng")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GodSaeng extends BaseTime {
+
+    private static final int DOING_WEEKS = 2;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "god_saeng_id")
@@ -28,9 +35,6 @@ public class GodSaeng extends BaseTime {
     @OneToMany(mappedBy = "godSaeng", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GodSaengWeek> weeks = new ArrayList<>();
 
-    @Enumerated(EnumType.STRING)
-    private GodSaengStatus status;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member owner;
@@ -39,10 +43,12 @@ public class GodSaeng extends BaseTime {
     @OneToMany(mappedBy = "godSaeng", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<GodSaengMember> members = new ArrayList<>();
 
-    public GodSaeng(String title, String description, List<GodSaengWeek> weeks, Member member) {
+    public GodSaeng(String title, String description, List<Week> weeks, Member member) {
         this.title = title;
         this.description = description;
-        this.weeks = weeks;
+        List<GodSaengWeek> godSaengWeeks = weeks.stream()
+                .map(week -> new GodSaengWeek(this, week)).collect(Collectors.toList());
+        this.weeks.addAll(godSaengWeeks);
         // 같생을 만든 사람은 자동 참여
         this.members.add(new GodSaengMember(this, member));
         this.owner = member;
@@ -59,5 +65,44 @@ public class GodSaeng extends BaseTime {
         for (Week week : weeks) {
             this.weeks.add(new GodSaengWeek(this,week));
         }
+    }
+
+    public GodSaengStatus getStatus() {
+        LocalDate now = LocalDate.now();
+        if (now.isAfter(getClosedDate())) {
+            return GodSaengStatus.DONE;
+        }
+        if (now.isBefore(getOpenedDate())) {
+            return GodSaengStatus.BEFORE;
+        }
+        return GodSaengStatus.PROCEEDING;
+    }
+
+    public LocalDate getOpenedDate() {
+        LocalDate now = LocalDate.now();
+        return now.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+    }
+
+    public LocalDate getClosedDate() {
+        LocalDate date = getOpenedDate();
+
+        for (int i = 0; i < DOING_WEEKS; i++) {
+            date = date.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+        }
+
+        return date.minusDays(1);
+    }
+
+    public List<LocalDate> getDoingDate() {
+        List<LocalDate> doingDates = new ArrayList<>();
+        LocalDate openedDate = getOpenedDate().minusDays(1);
+        for (int i = 0; i < DOING_WEEKS; i++) {
+            for (GodSaengWeek week : weeks) {
+                LocalDate nextDate = openedDate.with(TemporalAdjusters.next(week.toDayOfWeek()));
+                doingDates.add(nextDate);
+            }
+            openedDate = openedDate.plusWeeks(1);
+        }
+        return doingDates;
     }
 }

--- a/server/src/main/java/godsaeng/server/domain/GodSaengStatus.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaengStatus.java
@@ -1,5 +1,5 @@
 package godsaeng.server.domain;
 
 public enum GodSaengStatus {
-    OPEN, DOING, CLOSE
+    BEFORE, PROCEEDING, DONE
 }

--- a/server/src/main/java/godsaeng/server/domain/GodSaengWeek.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaengWeek.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.DayOfWeek;
 
 @Entity
 @Table(name = "god_saeng_week",uniqueConstraints = {
@@ -35,5 +36,9 @@ public class GodSaengWeek extends BaseTime {
     public GodSaengWeek(GodSaeng godSaeng, Week week) {
         this.godSaeng = godSaeng;
         this.week = week;
+    }
+
+    public DayOfWeek toDayOfWeek() {
+        return week.toDayOfWeek();
     }
 }

--- a/server/src/main/java/godsaeng/server/domain/Week.java
+++ b/server/src/main/java/godsaeng/server/domain/Week.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.DayOfWeek;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -13,20 +14,17 @@ import java.util.Objects;
 @Getter
 public enum Week {
 
-    MON("MON"),
-    TUE("TUE"),
-    WED("WED"),
-    THR("THR"),
-    FRI("FRI"),
-    SAT("SAT"),
-    SUN("SUN");
+    MON(1),
+    TUE(2),
+    WED(3),
+    THR(4),
+    FRI(5),
+    SAT(6),
+    SUN(7);
 
-    private String value;
+    private int value;
 
-    public static Week from(String value) {
-        return Arrays.stream(values())
-                .filter(it -> Objects.equals(it.value, value))
-                .findFirst()
-                .orElseThrow(InvalidPlatformException::new);
+    public DayOfWeek toDayOfWeek() {
+        return DayOfWeek.of(value);
     }
 }

--- a/server/src/main/java/godsaeng/server/dto/response/MonthlyGodSaengResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/MonthlyGodSaengResponse.java
@@ -1,0 +1,16 @@
+package godsaeng.server.dto.response;
+
+import godsaeng.server.domain.GodSaengStatus;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class MonthlyGodSaengResponse {
+
+    private LocalDate day;
+    private GodSaengStatus stauts;
+}

--- a/server/src/main/java/godsaeng/server/dto/response/MonthlyGodSaengsResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/MonthlyGodSaengsResponse.java
@@ -1,0 +1,14 @@
+package godsaeng.server.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class MonthlyGodSaengsResponse {
+
+    private List<MonthlyGodSaengResponse> monthlyGodsaengs;
+}

--- a/server/src/main/java/godsaeng/server/repository/GodSaengRepository.java
+++ b/server/src/main/java/godsaeng/server/repository/GodSaengRepository.java
@@ -4,7 +4,15 @@ import godsaeng.server.domain.GodSaeng;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 public interface GodSaengRepository extends JpaRepository<GodSaeng, Long> {
+
+    @Query("select g from GodSaengMember gm " +
+            "join gm.member m " +
+            "join gm.godSaeng g " +
+            "where m.id = :memberId and g.createdTime between :startDate and :endDate")
+    List<GodSaeng> findGodSaengsByBaseTime(Long memberId, Date startDate, Date endDate);
 }

--- a/server/src/main/java/godsaeng/server/service/GodSaengService.java
+++ b/server/src/main/java/godsaeng/server/service/GodSaengService.java
@@ -1,13 +1,8 @@
 package godsaeng.server.service;
 
-import godsaeng.server.domain.GodSaeng;
-import godsaeng.server.domain.GodSaengMember;
-import godsaeng.server.domain.GodSaengWeek;
-import godsaeng.server.domain.Member;
+import godsaeng.server.domain.*;
 import godsaeng.server.dto.request.GodSaengSaveRequest;
-import godsaeng.server.dto.response.GodSaengResponse;
-import godsaeng.server.dto.response.GodSaengSaveResponse;
-import godsaeng.server.dto.response.GodSaengsResponse;
+import godsaeng.server.dto.response.*;
 import godsaeng.server.exception.badrequest.DuplicateGodSaengException;
 import godsaeng.server.exception.badrequest.DuplicateWeekException;
 import godsaeng.server.exception.notfound.NotFoundGodSaengException;
@@ -20,8 +15,13 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -51,10 +51,10 @@ public class GodSaengService {
     public GodSaengsResponse findAllGodSaeng() {
         List<GodSaengResponse> godSaengResponses = godSaengRepository.findAll().stream()
                 .map(godSaeng -> new GodSaengResponse(
-                                godSaeng.getId(),
-                                godSaeng.getTitle(),
-                                godSaeng.getDescription(),
-                                godSaeng.getWeeks().stream().map(GodSaengWeek::getWeek).collect(Collectors.toList())))
+                        godSaeng.getId(),
+                        godSaeng.getTitle(),
+                        godSaeng.getDescription(),
+                        godSaeng.getWeeks().stream().map(GodSaengWeek::getWeek).collect(Collectors.toList())))
                 .collect(Collectors.toList());
         return new GodSaengsResponse(godSaengResponses);
     }
@@ -73,4 +73,66 @@ public class GodSaengService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public MonthlyGodSaengsResponse findMonthlyGodSaeng(Long memberId, LocalDate baseDate) {
+        YearMonth baseYearMonth = YearMonth.of(baseDate.getYear(), baseDate.getMonth());
+
+        LocalDate startOfBaseMonth = baseYearMonth.atDay(1);
+        LocalDate endOfBaseMonth = baseYearMonth.atEndOfMonth();
+
+        Date startDate = Date.from(startOfBaseMonth.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+        Date endDate = Date.from(endOfBaseMonth.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+
+        List<GodSaeng> godSaengs = godSaengRepository.findGodSaengsByBaseTime(memberId, startDate, endDate);
+
+        // 같생 기간이 원하는 달에 포함되는 같생들만 filter
+        List<GodSaeng> validGodsaengs =
+                getValidGodsaengs(startOfBaseMonth, endOfBaseMonth, godSaengs);
+
+        // 같생 날짜가 원하는 달에 포함된 날짜와 상태들만 filter
+        List<MonthlyGodSaengResponse> responses =
+                getValidGodsaengsDate(startOfBaseMonth, endOfBaseMonth, validGodsaengs);
+
+        // 같생이 겹칠 수 있기 때문에 날짜를 기준으로 그룹화
+        Map<LocalDate, List<MonthlyGodSaengResponse>> collect = responses.stream()
+                .collect(Collectors.groupingBy(MonthlyGodSaengResponse::getDay, Collectors.toList()));
+
+        List<MonthlyGodSaengResponse> monthlyGodSaengResponse = new ArrayList<>();
+
+        // 그룹화 했을 때 겹친다면 PROCEEDING을 가장 우선시 해서 넘김
+        // 겹칠 때 상태가 다른 경우는 하나만 PROCEEDING인 경우 밖에 없으므로 그 때만 예외처리
+        for (LocalDate localDate : collect.keySet()) {
+            List<MonthlyGodSaengResponse> monthlyGodSaengResponses = collect.get(localDate);
+            List<GodSaengStatus> statuses = monthlyGodSaengResponses.stream()
+                    .map(MonthlyGodSaengResponse::getStauts).collect(Collectors.toList());
+
+            if (hasProceedGodSaeng(statuses)) {
+                monthlyGodSaengResponse.add(new MonthlyGodSaengResponse(localDate, GodSaengStatus.PROCEEDING));
+                continue;
+            }
+            monthlyGodSaengResponse.add(monthlyGodSaengResponses.get(0));
+        }
+        return new MonthlyGodSaengsResponse(monthlyGodSaengResponse);
+    }
+
+    private boolean hasProceedGodSaeng(List<GodSaengStatus> statuses) {
+        return statuses.size() > 1 && statuses.contains(GodSaengStatus.PROCEEDING);
+    }
+
+    private List<MonthlyGodSaengResponse> getValidGodsaengsDate(LocalDate startOfBaseMonth, LocalDate endOfBaseMonth, List<GodSaeng> validGodsaengs) {
+        return validGodsaengs.stream()
+                .flatMap(validGodsaeng ->
+                        validGodsaeng.getDoingDate().stream()
+                                .filter(date -> date.isAfter(startOfBaseMonth.minusDays(1)))
+                                .filter(date -> date.isBefore(endOfBaseMonth.plusDays(1)))
+                                .map(localDate -> new MonthlyGodSaengResponse(localDate, validGodsaeng.getStatus())))
+                .collect(Collectors.toList());
+    }
+
+    private List<GodSaeng> getValidGodsaengs(LocalDate startOfBaseMonth, LocalDate endOfBaseMonth, List<GodSaeng> godSaengs) {
+        return godSaengs.stream()
+                .filter(godSaeng -> godSaeng.getClosedDate().isAfter(startOfBaseMonth))
+                .filter(godSaeng -> godSaeng.getOpenedDate().isBefore(endOfBaseMonth))
+                .collect(Collectors.toList());
+    }
 }

--- a/server/src/test/java/godsaeng/server/domain/GodSaengTest.java
+++ b/server/src/test/java/godsaeng/server/domain/GodSaengTest.java
@@ -1,0 +1,46 @@
+package godsaeng.server.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GodSaengTest {
+
+    @Test
+    void getOpenedDate() {
+        String title = "아침 6시 반 기상 갓생 살기";
+        String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
+        weeks.add(Week.WED);
+        weeks.add(Week.FRI);
+
+
+        String email1 = "rlawjddn103@naver.com";
+
+        GodSaeng godSaeng = new GodSaeng(title, description, weeks, new Member(email1, Platform.KAKAO, "11111"));
+        System.out.println("godSaeng.getOpenedDate() = " + godSaeng.getOpenedDate());
+        System.out.println("godSaeng.getClosedDate() = " + godSaeng.getClosedDate());
+        System.out.println("godSaeng.getDoingDate() = " + godSaeng.getDoingDate());
+
+    }
+
+    @Test
+    void getStatus() {
+        String title = "아침 6시 반 기상 갓생 살기";
+        String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
+        weeks.add(Week.WED);
+        weeks.add(Week.FRI);
+
+
+        String email1 = "rlawjddn103@naver.com";
+
+        GodSaeng godSaeng = new GodSaeng(title, description, weeks, new Member(email1, Platform.KAKAO, "11111"));
+        System.out.println("godSaeng.getOpenedDate() = " + godSaeng.getStatus());
+    }
+}

--- a/server/src/test/java/godsaeng/server/service/GodSaengServiceTest.java
+++ b/server/src/test/java/godsaeng/server/service/GodSaengServiceTest.java
@@ -4,6 +4,7 @@ import godsaeng.server.domain.*;
 import godsaeng.server.dto.request.GodSaengSaveRequest;
 import godsaeng.server.dto.response.GodSaengSaveResponse;
 import godsaeng.server.dto.response.GodSaengsResponse;
+import godsaeng.server.dto.response.MonthlyGodSaengsResponse;
 import godsaeng.server.exception.badrequest.DuplicateGodSaengException;
 import godsaeng.server.repository.GodSaengRepository;
 import godsaeng.server.repository.MemberRepository;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,8 +70,8 @@ class GodSaengServiceTest {
     void findAll() {
         String title = "아침 6시 반 기상 갓생 살기";
         String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
-        List<GodSaengWeek> weeks = new ArrayList<>();
-        weeks.add(new GodSaengWeek(Week.MON));
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
 
         String email = "rlawjddn103@naver.com";
         Member savedMember = memberRepository.save(new Member(email, Platform.KAKAO, "11111"));
@@ -91,8 +93,8 @@ class GodSaengServiceTest {
     void attendGodSaeng() {
         String title = "아침 6시 반 기상 갓생 살기";
         String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
-        List<GodSaengWeek> weeks = new ArrayList<>();
-        weeks.add(new GodSaengWeek(Week.MON));
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
 
         String email1 = "rlawjddn103@naver.com";
         Member savedMember1 = memberRepository.save(new Member(email1, Platform.KAKAO, "11111"));
@@ -117,8 +119,8 @@ class GodSaengServiceTest {
     void validateDuplicateAttendGodSaeng() {
         String title = "아침 6시 반 기상 갓생 살기";
         String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
-        List<GodSaengWeek> weeks = new ArrayList<>();
-        weeks.add(new GodSaengWeek(Week.MON));
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
 
         String email1 = "rlawjddn103@naver.com";
         Member savedMember1 = memberRepository.save(new Member(email1, Platform.KAKAO, "11111"));
@@ -134,5 +136,30 @@ class GodSaengServiceTest {
         em.flush();
 
         assertThrows(DuplicateGodSaengException.class, () -> godSaengService.attendGodSaeng(savedMember2.getId(), savedGodSaeng.getId()));
+    }
+
+    @DisplayName("월별 같생 목록을 조회할 수 있다.")
+    @Test
+    void monthlyGodSaeng() {String title = "아침 6시 반 기상 갓생 살기";
+        String description = "아침 6시 반 기상 후 유의미한 일을 하고 인증해야합니다.";
+        List<Week> weeks = new ArrayList<>();
+        weeks.add(Week.MON);
+        weeks.add(Week.WED);
+        weeks.add(Week.FRI);
+
+        String email1 = "rlawjddn103@naver.com";
+        Member savedMember1 = memberRepository.save(new Member(email1, Platform.KAKAO, "11111"));
+
+        String email2 = "rlawjddn102@naver.com";
+        memberRepository.save(new Member(email2, Platform.KAKAO, "12121"));
+
+        godSaengRepository.save(new GodSaeng(title, description, weeks, savedMember1));
+
+        em.clear();
+        em.flush();
+
+        MonthlyGodSaengsResponse monthlyGodSaeng = godSaengService.findMonthlyGodSaeng(1L, LocalDate.now());
+
+        // 테스트에 대한 고민 필요
     }
 }


### PR DESCRIPTION
## 작업사항
- GodSaengStatus는 날짜에 의해서 자동으로 정해지기 때문에 해당 컬럼을 삭제했습니다.
- createdTime을 기준으로 다음주 월요일날 같생 status는 Proceed로 판명됩니다.
- createdTime을 기준으로 3주뒤 월요일날 같생 status는 End로 판명됩니다.

### Service 복잡한 로직
- 월간 조회 시에 같생을 표현해야할 날짜 범위가 크기 때문에 이전 달부터 현재 달말까지 유저가 참여한 같생을 모두 가져옵니다.
- 그 같생들 중에 같생이 유효한 범위가 이번달이 아닌 경우 모두 제거합니다.
- 제거된 같생들 중에서도 같생에 포함되는 같생이 진행되는 날짜(월 수 금이면 3개의 날짜가 포함됨)가 원하는 달에 포함이 안될 수도 있기 때문에 이를 제거합니다.
- 만약 같생이 겹칠 때 진행 중인 같생을 우선해서 표현합니다. (이외의 경우에는 모두 같생이 겹쳐도 상태가 같습니다.)
위와 같은 복잡한 로직이 있어서 아마 이해하는데 오랜 시간이 걸릴 수 있습니다. 😥

## 주의사항
- 월간 조회 service 로직이 현재 매우매우 복잡합니다. 더 좋은 로직이 있을지 확인해주세요.
- 현재는 local에서 날짜를 기준으로 생성된 엔티티들의 createdTime을 변경할 수 없어 오늘 만든 같생을 제외하고는 테스트가 불가한데 좋은 테스트 방법이 있다면 알려주세요.