### PR TITLE
fix: 회원가입 로직을 프로필 이미지도 함께 등록하도록 수정

### DIFF
--- a/server/src/main/java/godsaeng/server/controller/MemberController.java
+++ b/server/src/main/java/godsaeng/server/controller/MemberController.java
@@ -36,8 +36,9 @@ public class MemberController {
 
     @Operation(summary = "OAuth 회원가입")
     @PostMapping("/oauth")
-    public ResponseEntity<OAuthMemberSignUpResponse> signUp(@RequestBody @Valid OAuthMemberSignUpRequest request) {
-        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request);
+    public ResponseEntity<OAuthMemberSignUpResponse> signUp(@RequestPart @Valid OAuthMemberSignUpRequest request,
+                                                            @RequestPart MultipartFile proofImg) {
+        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request, proofImg);
         return ResponseEntity.ok(response);
     }
 

--- a/server/src/main/java/godsaeng/server/controller/MemberController.java
+++ b/server/src/main/java/godsaeng/server/controller/MemberController.java
@@ -37,8 +37,8 @@ public class MemberController {
     @Operation(summary = "OAuth 회원가입")
     @PostMapping("/oauth")
     public ResponseEntity<OAuthMemberSignUpResponse> signUp(@RequestPart @Valid OAuthMemberSignUpRequest request,
-                                                            @RequestPart MultipartFile proofImg) {
-        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request, proofImg);
+                                                            @RequestPart MultipartFile file) {
+        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request, file);
         return ResponseEntity.ok(response);
     }
 

--- a/server/src/main/java/godsaeng/server/domain/Member.java
+++ b/server/src/main/java/godsaeng/server/domain/Member.java
@@ -72,8 +72,9 @@ public class Member extends BaseTime {
         this(email, password, nickname, null, Platform.GODSAENG, null);
     }
 
-    public void registerOAuthMember(String email, String nickname) {
+    public void registerOAuthMember(String email, String nickname, MemberProfileImage memberProfileImage) {
         validateNickname(nickname);
+        updateProfileImgUrl(memberProfileImage);
         this.nickname = nickname;
         if (email != null) {
             this.email = email;

--- a/server/src/main/java/godsaeng/server/service/MemberService.java
+++ b/server/src/main/java/godsaeng/server/service/MemberService.java
@@ -65,12 +65,15 @@ public class MemberService {
     }
 
     @Transactional
-    public OAuthMemberSignUpResponse signUpByOAuthMember(OAuthMemberSignUpRequest request) {
+    public OAuthMemberSignUpResponse signUpByOAuthMember(OAuthMemberSignUpRequest request, MultipartFile profileImg) {
         Platform platform = Platform.from(request.getPlatform());
         Member member = memberRepository.findByPlatformAndPlatformId(platform, request.getPlatformId())
                 .orElseThrow(NotFoundMemberException::new);
 
-        member.registerOAuthMember(request.getEmail(), request.getNickname());
+        String profileImgUrl = awsS3Uploader.uploadImage(profileImg);
+        MemberProfileImage memberProfileImage = new MemberProfileImage(profileImgUrl, true);
+        memberProfileImageRepository.save(memberProfileImage);
+        member.registerOAuthMember(request.getEmail(), request.getNickname(), memberProfileImage);
         return new OAuthMemberSignUpResponse(member.getId());
     }
 


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 회원가입 시, 이메일, 닉네임, 플랫폼 정보 뿐만 아니라 프로필 이미지를 함께 등록하도록 로직을 수정했습니다

**프론트에서 요청 시 아래와 같이 요청을 보내야 합니다**
<img width="866" alt="스크린샷 2023-08-15 오후 5 51 18" src="https://github.com/mocacong-hackathonKU/godsaeng/assets/69844138/c1341878-e112-44d3-af42-ccbadb6ec7ec">



## 작업사항
- 회원가입 로직에 프로필 이미지 등록 로직 추가
- 해당 작업사항으로 인한 테스트 코드 수정

## 주의사항
- 해당 변경사항은 OAuth 회원가입에만 적용이 되었으며 OAuth 관련 API이므로 포스트맨이나 스웨거로 해당 API를 테스트하기 힘듭니다. 대신 회원가입 관련 테스트에서 프로필 이미지 등록도 하도록 코드를 수정하였으니 테스트 코드를 참고해주세요
- 오타가 있는지 확인해주세요
- 기획에 어긋난 로직이 있으면 알려주세요
