### PR TITLE
style: 회원가입 및 인증 등록 API 바디 필드명 변경

### DIFF
--- a/server/src/main/java/godsaeng/server/controller/GodSaengController.java
+++ b/server/src/main/java/godsaeng/server/controller/GodSaengController.java
@@ -68,9 +68,9 @@ public class GodSaengController {
             MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ProofSaveResponse> saveProof(@LoginUserId Long memberId,
                                                        @PathVariable Long godSaengId,
-                                                       @RequestPart ProofSaveRequest request,
+                                                       @RequestPart ProofSaveRequest proof,
                                                        @RequestPart MultipartFile proofImg) {
-        ProofSaveResponse response = godSaengService.saveProof(memberId, godSaengId, proofImg, request);
+        ProofSaveResponse response = godSaengService.saveProof(memberId, godSaengId, proofImg, proof);
         return ResponseEntity.ok(response);
     }
 }

--- a/server/src/main/java/godsaeng/server/controller/MemberController.java
+++ b/server/src/main/java/godsaeng/server/controller/MemberController.java
@@ -37,9 +37,9 @@ public class MemberController {
 
     @Operation(summary = "OAuth 회원가입")
     @PostMapping("/oauth")
-    public ResponseEntity<OAuthMemberSignUpResponse> signUp(@RequestPart @Valid OAuthMemberSignUpRequest request,
-                                                            @RequestPart MultipartFile file) {
-        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request, file);
+    public ResponseEntity<OAuthMemberSignUpResponse> signUp(@RequestPart @Valid OAuthMemberSignUpRequest member,
+                                                            @RequestPart MultipartFile profileImg) {
+        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(member, profileImg);
         return ResponseEntity.ok(response);
     }
 

--- a/server/src/main/java/godsaeng/server/controller/MemberController.java
+++ b/server/src/main/java/godsaeng/server/controller/MemberController.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
+
 @Tag(name = "Members", description = "회원")
 @RestController
 @RequiredArgsConstructor

--- a/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
+++ b/server/src/main/java/godsaeng/server/dto/request/ProofSaveRequest.java
@@ -11,5 +11,5 @@ import javax.validation.constraints.NotBlank;
 public class ProofSaveRequest {
 
     @NotBlank(message = "2001:공백일 수 없습니다.")
-    private String proofContent;
+    private String content;
 }

--- a/server/src/main/java/godsaeng/server/service/GodSaengService.java
+++ b/server/src/main/java/godsaeng/server/service/GodSaengService.java
@@ -150,7 +150,7 @@ public class GodSaengService {
         validateProofCondition(member, godSaeng);
 
         try {
-            String content = request.getProofContent();
+            String content = request.getContent();
             ProofImage proofImage = saveProofImage(godSaengId, proofImg);
             Proof proof = new Proof(content, godSaeng, proofImage, member);
             return new ProofSaveResponse(proofRepository.save(proof).getId());


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 회원가입 및 인증 등록 API에 대해 요청 바디에 들어가는 필드 명을 변경했습니다.

## 작업사항
- 회원가입 POST API 바디 필드명 변경
- 인증 등록 POST API 바디 필드명 변경

## 주의사항