### PR TITLE
feat: 같생 일간 조회에 isDone 정보 추가

### DIFF
--- a/server/src/main/java/godsaeng/server/domain/GodSaeng.java
+++ b/server/src/main/java/godsaeng/server/domain/GodSaeng.java
@@ -35,6 +35,9 @@ public class GodSaeng extends BaseTime {
     @OneToMany(mappedBy = "godSaeng", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private List<GodSaengWeek> weeks = new ArrayList<>();
 
+    @OneToMany(mappedBy = "godSaeng", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Proof> proofs = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member owner;

--- a/server/src/main/java/godsaeng/server/domain/Proof.java
+++ b/server/src/main/java/godsaeng/server/domain/Proof.java
@@ -7,7 +7,9 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity
-@Table(name = "proof")
+@Table(name = "proof", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"god_saeng_id", "member_id"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Proof extends BaseTime {
@@ -41,5 +43,9 @@ public class Proof extends BaseTime {
 
     public static void removeMember(Proof proof) {
         proof.member = null;
+    }
+
+    public boolean isSameGodSaeng(GodSaeng godSaeng) {
+        return godSaeng.getId().equals(this.godSaeng.getId());
     }
 }

--- a/server/src/main/java/godsaeng/server/dto/response/DailyGodSaengResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/DailyGodSaengResponse.java
@@ -12,5 +12,5 @@ public class DailyGodSaengResponse {
     private long id;
     private String title;
     private GodSaengStatus stauts;
-    private boolean isDone;
+    private Boolean isDone;
 }

--- a/server/src/main/java/godsaeng/server/dto/response/DailyGodSaengResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/DailyGodSaengResponse.java
@@ -12,4 +12,5 @@ public class DailyGodSaengResponse {
     private long id;
     private String title;
     private GodSaengStatus stauts;
+    private boolean isDone;
 }

--- a/server/src/main/java/godsaeng/server/dto/response/GodSaengDetailResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/GodSaengDetailResponse.java
@@ -20,7 +20,7 @@ public class GodSaengDetailResponse {
     private List<GodSaengMemberResponse> members;
     private int progress;
     private GodSaengStatus status;
-    private boolean isJoined;
+    private Boolean isJoined;
     private List<ProofResponse> proofs;
 
     public static GodSaengDetailResponse from(GodSaeng godSaeng, List<Member> members, List<Proof> proofs, int progress, boolean isJoined) {

--- a/server/src/main/java/godsaeng/server/dto/response/GodSaengResponse.java
+++ b/server/src/main/java/godsaeng/server/dto/response/GodSaengResponse.java
@@ -13,5 +13,5 @@ public class GodSaengResponse {
     private Long id;
     private String title;
     private String description;
-    private List<Week> week;
+    private List<Week> weeks;
 }

--- a/server/src/main/java/godsaeng/server/repository/ProofRepository.java
+++ b/server/src/main/java/godsaeng/server/repository/ProofRepository.java
@@ -6,6 +6,7 @@ import godsaeng.server.domain.Proof;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +17,9 @@ public interface ProofRepository extends JpaRepository<Proof, Long> {
 
     @Query("select p from Proof p join fetch p.member m where p.godSaeng.id = :godSaengId")
     List<Proof> findProofsWithMemberByGodSaengId(Long godSaengId);
+
+    @Query("select p from Proof p " +
+            "join fetch p.godSaeng g " +
+            "where p.member.id = :memberId and p.createdTime between :startDate and :endDate")
+    List<Proof> findProofWithGodSaengByMemberId(Long memberId, Date startDate, Date endDate);
 }

--- a/server/src/test/java/godsaeng/server/service/GodSaengServiceTest.java
+++ b/server/src/test/java/godsaeng/server/service/GodSaengServiceTest.java
@@ -295,7 +295,7 @@ class GodSaengServiceTest {
                 () -> assertEquals(description, response.getDescription()),
                 () -> assertEquals(0, response.getProgress()),
                 () -> assertEquals(1, response.getMembers().size()),
-                () -> assertTrue(response.isJoined())
+                () -> assertTrue(response.getIsJoined())
         );
 
     }


### PR DESCRIPTION
## 개요
같생 일간 조회에 해당 같생이 인증되었는지 확인하는 기능을 구현했습니다.

## 작업사항
- 원하는 날짜의 유저가 한 인증 정보를 불러옵니다. 
- 그 날에 해당하는 같생들의 id와 인증의 같생 id를 비교하여 유저의 같생 인증이 있다면 true를 아니라면 false를 반환합니다.

## 주의사항
- 더 좋은 로직이 있다면 알려주세요.
- 현재 인증정보가 거의 없어 db에 저장된 인증 정보 8월 14일로만 테스트 할 수 있습니다.