### PR TITLE
feat: 서버 에러 발생 시 슬랙 알림 기능 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+    implementation 'com.slack.api:slack-api-client:1.29.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/server/src/main/java/godsaeng/server/controller/ControllerAdvice.java
+++ b/server/src/main/java/godsaeng/server/controller/ControllerAdvice.java
@@ -1,10 +1,14 @@
 package godsaeng.server.controller;
 
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
 import godsaeng.server.dto.response.ErrorResponse;
 import godsaeng.server.exception.GodsaengException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.FileUploadException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -18,7 +22,13 @@ import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -27,6 +37,11 @@ public class ControllerAdvice {
 
     private static final int FIELD_ERROR_CODE_INDEX = 0;
     private static final int FIELD_ERROR_MESSAGE_INDEX = 1;
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleInputFieldException(MethodArgumentNotValidException e) {
@@ -107,7 +122,45 @@ public class ControllerAdvice {
                 request.getRequestURI(),
                 e.getMessage()
         );
+        sendSlackAlertErrorLog(e, request);
         return ResponseEntity.internalServerError()
                 .body(new ErrorResponse(9999, "일시적으로 접속이 원활하지 않습니다. 같생 서비스 팀에 문의 부탁드립니다."));
+    }
+
+    private void sendSlackAlertErrorLog(Exception e, HttpServletRequest request) {
+        try {
+            slackClient.send(webhookUrl, payload(p -> p
+                    .text("서버 에러 발생! 백엔드 측의 빠른 확인 요망")
+                    .attachments(
+                            List.of(generateSlackAttachment(e, request))
+                    )
+            ));
+        } catch (IOException slackError) {
+            log.debug("Slack 통신과의 예외 발생");
+        }
+    }
+
+    private Attachment generateSlackAttachment(Exception e, HttpServletRequest request) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        String xffHeader = request.getHeader("X-FORWARDED-FOR");
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + " 발생 에러 로그")
+                .fields(List.of(
+                        generateSlackField("Request IP", xffHeader == null ? request.getRemoteAddr() : xffHeader),
+                                generateSlackField("Request URL", request.getRequestURL() + " " +
+                                        request.getMethod()),
+                                generateSlackField("Error Message", e.getMessage())
+                        )
+                )
+                .build();
+    }
+
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(false)
+                .build();
     }
 }

--- a/server/src/main/java/godsaeng/server/controller/MemberController.java
+++ b/server/src/main/java/godsaeng/server/controller/MemberController.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
+
 @Tag(name = "Members", description = "회원")
 @RestController
 @RequiredArgsConstructor

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -59,3 +59,7 @@ cloud:
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -46,3 +46,7 @@ cloud:
     credentials:
       access-key: test
       secret-key: test
+
+slack:
+  webhook:
+    url: test


### PR DESCRIPTION
## 개요
- 500 에러가 발생하는 경우, 직접 슬랙을 통해 알려야 하는 번거로움을 줄이기 위해 서버 에러가 발생하면 자동으로 슬랙에 알림을 주는 기능을 추가했습니다

## 작업사항
- internal server error (500번대 에러) 발생 시에 슬랙에 알림을 보내도록 구현했습니다.
- MavenRepository를 참고하여 비교적 최신이면서도 가장 안정적인 `slack-api-client:1.29.0` 의존성을 추가했습니다. 
<img width="932" alt="image" src="https://user-images.githubusercontent.com/57135043/231928159-0077c44c-fcda-407e-8d79-df4b661aa578.png">

- 알림 예시는 아래와 같습니다.

<img width="595" alt="image" src="https://github.com/mocacong-hackathonKU/godsaeng/assets/69844138/bd3d68f0-defe-4d42-97ab-e89156b30fae">


## 주의사항
- 로컬 환경에서 직접 테스트해보고 싶을 경우 환경변수를 주입해야 합니다
