### PR TITLE
fix: ProofImage에서 GodSaeng 엔티티 연관관계 삭제

### DIFF
--- a/server/src/main/java/godsaeng/server/controller/MemberController.java
+++ b/server/src/main/java/godsaeng/server/controller/MemberController.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
+
 @Tag(name = "Members", description = "회원")
 @RestController
 @RequiredArgsConstructor

--- a/server/src/main/java/godsaeng/server/domain/ProofImage.java
+++ b/server/src/main/java/godsaeng/server/domain/ProofImage.java
@@ -21,15 +21,6 @@ public class ProofImage extends BaseTime {
     @Column(name = "img_url", nullable = false)
     private String imgUrl;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "god_saeng_id")
-    private GodSaeng godSaeng;
-
-    public ProofImage(String imgUrl, GodSaeng godSaeng) {
-        this.imgUrl = imgUrl;
-        this.godSaeng = godSaeng;
-    }
-
     public ProofImage(String imgUrl) {
         this.imgUrl = imgUrl;
     }

--- a/server/src/main/java/godsaeng/server/service/GodSaengService.java
+++ b/server/src/main/java/godsaeng/server/service/GodSaengService.java
@@ -230,7 +230,7 @@ public class GodSaengService {
         }
 
         String proofImgUrl = awsS3Uploader.uploadImage(proofImg);
-        ProofImage proofImage = new ProofImage(proofImgUrl, godSaeng);
+        ProofImage proofImage = new ProofImage(proofImgUrl);
         proofImageRepository.save(proofImage);
         return proofImage;
     }


### PR DESCRIPTION
## 개요
- 기존 ProofImage 엔티티는 GodSaeng 엔티티와 연관관계를 가지고 있었지만 필요없다고 판단하여 연관관계를 삭제했습니다

## 작업사항
- ProofImage 엔티티에서 GodSaeng 엔티티 연관관계 삭제
- 그에 따른 서비스 로직 수정

## 주의사항
- 해당 변경사항이 적용된 후에도 제대로 작동하는 지 확인해주세요